### PR TITLE
chore: connection to rabbitmq + consumer creation

### DIFF
--- a/src/main/java/com/ms/mail/configs/RabbitMQConfig.java
+++ b/src/main/java/com/ms/mail/configs/RabbitMQConfig.java
@@ -1,0 +1,25 @@
+package com.ms.mail.configs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+    @Value("${broker.queue.email.name}")
+    private String queue;
+
+    @Bean
+    public Queue queue() {
+        return new Queue(queue, true);
+    }
+
+    @Bean
+    public Jackson2JsonMessageConverter messageConverter() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        return new Jackson2JsonMessageConverter(objectMapper);
+    }
+}

--- a/src/main/java/com/ms/mail/consumers/EmailConsumer.java
+++ b/src/main/java/com/ms/mail/consumers/EmailConsumer.java
@@ -1,0 +1,15 @@
+package com.ms.mail.consumers;
+
+import com.ms.mail.dtos.EmailRecordDto;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EmailConsumer {
+
+    @RabbitListener(queues = "${broker.queue.email.name}")
+    public void listenerEmailQueue(@Payload EmailRecordDto emailRecordDto) {
+        System.out.println(emailRecordDto.emailTo());
+    }
+}

--- a/src/main/java/com/ms/mail/dtos/EmailRecordDto.java
+++ b/src/main/java/com/ms/mail/dtos/EmailRecordDto.java
@@ -1,0 +1,9 @@
+package com.ms.mail.dtos;
+
+import java.util.UUID;
+
+public record EmailRecordDto(UUID userId,
+                             String emailTo,
+                             String subject,
+                             String text) {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,7 @@ spring.datasource.url= jdbc:postgresql://localhost:5432/ms-mail
 spring.datasource.username=root
 spring.datasource.password=root
 spring.jpa.hibernate.ddl-auto=update
+
+spring.rabbitmq.addresses=amqps://kdkjzudw:ZLfDN38aPSsXbwYWu-Md1ljHo2Vy9pA6@whale.rmq.cloudamqp.com/kdkjzudw
+
+broker.queue.email.name=default.email


### PR DESCRIPTION
Acesse <a href='cloudamqp.com'>cloudamqp.com</a> e crie uma instância.
Obs: Crie uma conta antes.

Selecione next em todas as opções, para ser usado de modo free.

Após criar a instância, acesse-a para visualizar os dados de conexão.

Em AMQP Details haverá um URL que será inserida dentro das propriedades de cada ms para acessar essa plataforma (instância). Então, copie-a.


Outra funcionalidade importante do cloud amqp é o *RabbitMQ Manager*, que é uma interface para visualizar as `exchanges` e `queues` criadas para o controle de mensagem que chegarão e serão consumidas.

*Exchanges* -> No RabbitMQ, um produtor nunca envia uma mensagem diretamente para uma fila. Em vez disso, ele usa uma troca como mediador de roteamento. Portanto, a exchange decide se a mensagem vai para uma fila, para múltiplas filas ou é simplesmente descartada.
De: <a href='https://www.baeldung.com/java-rabbitmq-exchanges-queues-bindings#:~:text=In%20RabbitMQ%2C%20a%20producer%20never,queues%2C%20or%20is%20simply%20discarded.'>Exchanges</a>


<h5>Conexão do RabbitMQ no MS Email</h5>

Para a conexão no Rabbit MQ, foi utilizado `spring.rabbitmq.addresses=` 
o endereço inserido vai ser justamente o que a cloudamqp sugeriu, no meu caso:
`amqps://kdkjzudw:ZLfDN38aPSsXbwYWu-Md1ljHo2Vy9pA6@whale.rmq.cloudamqp.com/kdkjzudw`
Dessa forma, será possível fazer a conexão com o `broker`. E possivelmente, receber, enviar mensagens, etc.

*broker* -> Um **broker** no contexto de mensageria, como no RabbitMQ, é o componente que atua como intermediário na transmissão de mensagens entre produtores (aplicações que enviam mensagens) e consumidores (aplicações que recebem mensagens). Ele é responsável por receber, armazenar e encaminhar mensagens, garantindo que as mensagens cheguem aos seus destinos, mesmo que os consumidores não estejam prontos para recebê-las imediatamente.


<h5>Classe de configuração RabbitMQ</h5>
Uma coisa importante é a classe de configuração do RabbitMQ, pois será iniciado uma fila (queue), uma fila que vai receber as mensagens e o micro service vai se conectar com essa fila para sempre consumir as mensagens que chegarão.

No projeto, criar um package `configs` e dentro dela criar uma classe de configuração do Spring.
Para que ela seja uma classe de configuração, deve ser anotada com `@Configuration`.

Agora, antes de criar, a fila deverá ter um nome antes de ser criada dentro do `broker`.

Antes de codificar o nome para essa fila, é necessário definir nas `propriedades` o nome para essa fila. E para seguir o padrão deixando ele sustentável:
`broker.queue.email.name=`

Isso é feito para evitar a confusão no painel de exchange do Rabbit.
Então, para olhar e saber qual exchange pertence é bom colocar o nome da exchange + root key
`broker.queue.email.name=default.email`
`default -> nome da exchange`
`root key -> email`

Feito isso, na classe de configuração do Rabbit, é necessário recuperar o valor passado via `properties`

Para isso, será utilizado o `@Value`, dentro dele, haverá o valor literal que foi passado no `properties`, no caso: `broker.queue.email.name` para ele ter acesso a esse valor.

Logo abaixo, será inicializado a fila para o `broker`, utilizando um método produtor `@Bean` para deixar explicito ao Spring que uma `Queue` será criada quando for necessário. E então criar uma nova instância de `Queue` passando seu nome e se é durável ou não.

*Duravel -> Caso o broker caia, a fila será preservada.*


<h5>Consumer</h5>

este microservice precisará consumir as mensagens que estão chegando em tal fila, e para isso, é necessário declarar um `Consumer`.

`New Package -> .consumers.`
`consumers -> New Class -> EmailConsumer`

o EmailConsumir também será um `Bean` do Spring, porém um Bean mais genérico por isso será utilizado a anotação `@Component`

E dentro do método vai ser criado o ouvinte, que realmente vai consumir as mensagens da fila. No caso o método `listenEmailQueue`

Para esse método realmente ser o ouvinte, é necessário utilizar da anotação `@RabbitListener` passando a fila na qual ele vai consumir.

E também de `@Payload`. `@Payload` vai receber o conteúdo (corpo) da mensagem que vai ser enviado nessa comunicação assíncrona.

Para teste, use dentro do método o `System.out.println(string)`.

Após rodar a aplicação, no Manager do RabbitMQ a fila `default.email` deve ser exibida.
Clique nela e acesse a aba `Payload`, insira um texto e publique. No log da sua IDE deve ser exibido a mensagem que foi publicada.


<h5>Criando DTO Email</h5>

Para receber esse `dto` é necessário ter um `record`.

Esse record vai receber como registro, o id do usuário, um email para, uma descrição e o texto, assim possuindo esses 4 atributos.

Com o registro criado, é só substituir no `consumer / método listener` de `String string` (usado para teste) para `EmailRecordDto`.


Um detalhe é que além do `@Bean` declarando qual fila será criada, será necessário também uma configuração de conversão, utilizando do `Jackson2JsonMessageConverter messageConverter()` e uma instancia do `ObjectMapper`.
Isso na classe configurações do RabbitMQ.

*Jackson2JsonMessageConverter messageConverter()* -> O `AmqpTemplate` também define vários métodos para enviar e receber mensagens que delegam a um `MessageConverter`. O `MessageConverter` fornece um único método para cada direção: um para converter **para uma** Message e outro para converter **de uma** Message.

Essa conversão está sendo usada pois está sendo recebido/escutado mensagens do `@Payload` (corpo da mensagem com json) para depois estar sendo feito a conversão para o `EmalRecordDto` receber esse tipo em Java.
Resumindo, o `messageConverter` entra como algo para evitar erro na conversão.

*ObjectMapper* -> O ObjectMapper fornece funcionalidade para leitura e gravação de JSON, tanto para POJOs básicos (Plain Old Java Objects) quanto para um JSON Tree Model de uso geral (JsonNode), bem como funcionalidade relacionada para realizar conversões.

**Resumo messageConverter() + ObjectMapper**:
O método messageConverter irá receber o valor do corpo da requisição no listener / escuta, e após isso, o Object Mapper irá captar isso e fornecer uma leitura para o Jackson2JsonMessageConverter realizar a conversão.

Consumer finalizado!